### PR TITLE
mic_nuc.f90 bug fix - dimension of concen_tab

### DIFF
--- a/src/micro/mic_nuc.f90
+++ b/src/micro/mic_nuc.f90
@@ -13,7 +13,7 @@ real, dimension(m1) :: rv,wp,dn0
 real :: tairc_nuc,w_nuc,rg_nuc,tab,sfcareatotal
 real :: rjw,wtw1,wtw2,rjconcen,wtcon1,wtcon2,jrg1,jrg2,eps1,eps2
 real :: total_cld_nucc,total_drz_nucc,total_cld_nucr,total_drz_nucr
-real, dimension(9) :: concen_tab
+real, dimension(aerocat) :: concen_tab
 
 !Re-set cloud layer before nucleation
 k1cnuc = 2


### PR DESCRIPTION
Now that aerocat = 11 rather than 9, concen_tab should have a dimension of 11 rather than 9. Rather than hard-coding the value 11, I've changed the dimension to equal the value of aerocat. OLD: real, dimension(9) :: concen_tab
NEW: real, dimension(aerocat) :: concen_tab